### PR TITLE
Fixing protected method

### DIFF
--- a/src/CustomerSecretsFakeClient.php
+++ b/src/CustomerSecretsFakeClient.php
@@ -7,6 +7,8 @@
 
 namespace PantheonSystems\CustomerSecrets;
 
+use Exception;
+
 /**
  *
  */
@@ -84,11 +86,12 @@ class CustomerSecretsFakeClient extends CustomerSecretsClientBase implements Cus
         return $this->file;
     }
 
-  /**
-   * @param string $filepath
-   *
-   * @return void
-   */
+    /**
+     * @param string $filepath
+     *
+     * @return void
+     * @throws Exception
+     */
     public function setFilepath(string $filepath): void
     {
         $this->file = $filepath;
@@ -100,7 +103,7 @@ class CustomerSecretsFakeClient extends CustomerSecretsClientBase implements Cus
   /**
    * Fetches secret data for current site.
    *
-   * @throws \Exception
+   * @throws Exception
    */
     protected function fetchSecrets(): void
     {

--- a/src/CustomerSecretsFakeClient.php
+++ b/src/CustomerSecretsFakeClient.php
@@ -92,6 +92,7 @@ class CustomerSecretsFakeClient extends CustomerSecretsClientBase implements Cus
     public function setFilepath(string $filepath): void
     {
         $this->file = $filepath;
+        $this->fetchSecrets();
     }
 
   /**
@@ -99,7 +100,7 @@ class CustomerSecretsFakeClient extends CustomerSecretsClientBase implements Cus
    *
    * @throws \Exception
    */
-    public function fetchSecrets(): void
+    protected function fetchSecrets(): void
     {
         if (file_exists($this->file)) {
             $this->secretList = SecretList::fromJson(file_get_contents($this->getFilepath()));

--- a/src/CustomerSecretsFakeClient.php
+++ b/src/CustomerSecretsFakeClient.php
@@ -92,6 +92,8 @@ class CustomerSecretsFakeClient extends CustomerSecretsClientBase implements Cus
     public function setFilepath(string $filepath): void
     {
         $this->file = $filepath;
+        // The reason this exists, is because the secret values need to be populated
+        // once the value is set. This is a bit of a hack, but it works.
         $this->fetchSecrets();
     }
 

--- a/tests/Functional/CustomerSecretsFakeClientTest.php
+++ b/tests/Functional/CustomerSecretsFakeClientTest.php
@@ -60,7 +60,6 @@ class CustomerSecretsFakeClientTest extends TestCase
     {
         $filepath = __DIR__ . '/../Fixtures/' . $filename;
         $this->fakeClient->setFilepath($filepath);
-        $this->fakeClient->fetchSecrets();
         $secrets = $this->fakeClient->getSecrets();
         $metadata = $this->fakeClient->getSecretsMetadata();
 


### PR DESCRIPTION
By calling the method immediately after we set the file value, fetchSecrets need not be public.