### PR TITLE
Check for default org secrets

### DIFF
--- a/src/SecretList.php
+++ b/src/SecretList.php
@@ -87,7 +87,8 @@ class SecretList
         $secrets = [];
         $metadata = [];
         foreach ($data['Secrets'] as $name => $secretResult) {
-            $secrets[$name] = new Secret($name, $secretResult['Value'], $secretResult['Type'], $secretResult['Scopes']);
+            $secretValue = empty($secretResult['Value']) ? $secretResult['OrgValues']['default'] : $secretResult['Value'];
+            $secrets[$name] = new Secret($name, $secretValue, $secretResult['Type'], $secretResult['Scopes']);
         }
         $toReturn = new static($secrets);
         $toReturn->setSecretListMetadataFromUntypedArray($data);


### PR DESCRIPTION
Allows an org value to be set if only org secrets are set and there is no override. 

Reopening since code changed and updating my fork closed #13. Thanks!

