### PR TITLE
Fix PHP Warning in CustomerSecretsClient.php

### DIFF
--- a/src/CustomerSecretsClient.php
+++ b/src/CustomerSecretsClient.php
@@ -54,8 +54,10 @@ class CustomerSecretsClient extends CustomerSecretsClientBase implements Custome
         $secretResults = $this->internalClient->get();
         $this->secretList->setMetadata($this->secretListMetadata($secretResults));
         $secrets = [];
-        foreach ($secretResults['Secrets'] as $name => $secretResult) {
-            $secrets[$name] = new Secret($name, $secretResult['Value'], $secretResult['Type'], $secretResult['Scopes']);
+        if (isset($secretResults['Secrets'])) {
+            foreach ($secretResults['Secrets'] as $name => $secretResult) {
+                $secrets[$name] = new Secret($name, $secretResult['Value'], $secretResult['Type'], $secretResult['Scopes']);
+            }
         }
         $this->secretList->setSecrets($secrets);
     }


### PR DESCRIPTION
Warning: Undefined array key "Secrets" in PantheonSystems\CustomerSecrets\CustomerSecretsClient->fetchSecrets() (line 57 of /code/vendor/pantheon-systems/customer-secrets-php-sdk/src/CustomerSecretsClient.php).
Warning: foreach() argument must be of type array|object, null given in PantheonSystems\CustomerSecrets\CustomerSecretsClient->fetchSecrets() (line 57 of /code/vendor/pantheon-systems/customer-secrets-php-sdk/src/CustomerSecretsClient.php).