### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Tests
+permissions:
+  contents: read
 on:
   push:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/pantheon-systems/customer-secrets-php-sdk/security/code-scanning/2](https://github.com/pantheon-systems/customer-secrets-php-sdk/security/code-scanning/2)

In general, to fix this you should explicitly define a `permissions:` block for the workflow (or per job) that grants only the minimal scopes needed. For a pure test/CI workflow that only checks out code and runs tests, `contents: read` is sufficient. Adding this at the root (next to `name:` and `on:`) ensures both `phpcs` and `functional` inherit restricted permissions without changing any job logic.

The best minimal fix here is to add a workflow-level `permissions:` block right after the `name: CI Tests` line in `.github/workflows/ci.yml`:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
  below line 1.  
- Leave the rest of the file unchanged.  
This documents that the workflow only needs read access to the repository contents and constrains the `GITHUB_TOKEN` accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
