### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Tests
+permissions:
+  contents: read
 on:
   push:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/pantheon-systems/customer-secrets-php-sdk/security/code-scanning/1](https://github.com/pantheon-systems/customer-secrets-php-sdk/security/code-scanning/1)

In general, fix this by adding an explicit `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scopes needed. For this workflow, the jobs only need to read repository contents, so `contents: read` is sufficient. Defining this at the workflow root will apply to all jobs that do not override it.

The best fix with no functional change is to add a root-level `permissions:` block right after the `name:` line (before `on:`). This keeps the workflow behavior identical while ensuring the token can only read repository contents (and not write to issues, PRs, etc.). No imports or additional methods are required because this is a YAML configuration change only.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI Tests`). All other lines remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
