### PR TITLE
fix: restrict CI workflow permissions to address GHAS alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI Tests
+
+permissions:
+  contents: read
+
 on:
   push:
   schedule:


### PR DESCRIPTION
## Summary

Combines the identical changes from two Copilot Autofix PRs (#34 and #35), which both proposed the same fix to the same file:

Adds `permissions: contents: read` at the workflow level of `.github/workflows/ci.yml` to address GHAS alert `actions/missing-workflow-permissions` (code scanning alerts #1 and #2).

Closes #34 and #35.